### PR TITLE
添加多端口轮询功能

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,76 +1,76 @@
 {
-    "napcat_host": {
-        "type": "string",
-        "description": "Napcat连接地址",
-        "hint": "格式：IP:端口，例如 127.0.0.1:3000",
-        "default": "127.0.0.1:3000",
-        "obvious_hint": true
-    },
-        "enable_advanced_globally": {
-        "description": "【全局开关】一键开启所有群的进阶功能",
-        "type": "bool",
-        "hint": "开启后，所有群聊都将默认启用进阶功能（许愿/强娶/锁定），无需再逐个使用命令开启。默认关闭。",
-        "default": false
-    },
-    "request_timeout": {
-        "type": "int",
-        "description": "请求超时时间（秒）",
-        "hint": "推荐值10-30秒",
-        "default": 10
-    },
-    "max_daily_breakups": {
-        "type": "int",
-        "description": "每日最大分手次数",
-        "hint": "超过此次数将自动屏蔽用户",
-        "default": 3
-    },
-    "breakup_block_hours": {
-        "type": "int",
-        "description": "超限屏蔽时长（小时）",
-        "hint": "触发次数限制后的屏蔽时长",
-        "default": 24
-    },
-    "default_cooling_hours": {
-        "type": "int",
-        "description": "默认冷静期时长（小时）",
-        "hint": "建议48-168小时",
-        "default": 48
-    },
-    "display_name_max_length": {
-        "type": "int",
-        "description": "昵称显示最大长度",
-        "hint": "超过该长度将显示为省略号 (建议10-15)",
-        "default": 10
-    },
-    "max_daily_wishes": {
-        "type": "int",
-        "description": "每日最多许愿次数",
-        "hint": "每个用户每日允许使用许愿功能的次数",
-        "default": 1
-    },
-    "max_daily_rob_attempts": {
-        "type": "int",
-        "description": "每日最多强娶次数",
-        "hint": "每个用户每日允许使用强娶功能的次数（成功与否均扣减）",
-        "default": 2
-    },
-    "max_daily_lock": {
-        "type": "int",
-        "description": "每日最多锁定次数",
-        "hint": "每个用户每日允许使用锁定功能的次数",
-        "default": 1
-    },
-    "show_avatar": {
-        "type": "bool",
-        "description": "是否显示伴侣头像",
-        "hint": "开启后在查询和配对成功消息中显示伴侣头像",
-        "default": true
-      },
-      "avatar_size": {
-        "type": "int",
-        "description": "伴侣头像尺寸规格",
-        "hint": "可选值：1, 2, 3, 4, 5, 40, 100, 140, 640。对应不同头像大小。",
-        "default": 640,
-        "options": [1, 2, 3, 4, 5, 40, 100, 140, 640] 
-      }
+  "napcat_host": {
+    "type": "string",
+    "description": "Napcat连接地址（支持多个，用逗号分隔）",
+    "hint": "格式：IP:端口，多个地址用逗号分隔，例如 127.0.0.1:3000,127.0.0.1:3001",
+    "default": "127.0.0.1:3000",
+    "obvious_hint": true
+  },
+  "enable_advanced_globally": {
+    "description": "【全局开关】一键开启所有群的进阶功能",
+    "type": "bool",
+    "hint": "开启后，所有群聊都将默认启用进阶功能（许愿/强娶/锁定），无需再逐个使用命令开启。默认关闭。",
+    "default": false
+  },
+  "request_timeout": {
+    "type": "int",
+    "description": "请求超时时间（秒）",
+    "hint": "推荐值10-30秒",
+    "default": 10
+  },
+  "max_daily_breakups": {
+    "type": "int",
+    "description": "每日最大分手次数",
+    "hint": "超过此次数将自动屏蔽用户",
+    "default": 3
+  },
+  "breakup_block_hours": {
+    "type": "int",
+    "description": "超限屏蔽时长（小时）",
+    "hint": "触发次数限制后的屏蔽时长",
+    "default": 24
+  },
+  "default_cooling_hours": {
+    "type": "int",
+    "description": "默认冷静期时长（小时）",
+    "hint": "建议48-168小时",
+    "default": 48
+  },
+  "display_name_max_length": {
+    "type": "int",
+    "description": "昵称显示最大长度",
+    "hint": "超过该长度将显示为省略号 (建议10-15)",
+    "default": 10
+  },
+  "max_daily_wishes": {
+    "type": "int",
+    "description": "每日最多许愿次数",
+    "hint": "每个用户每日允许使用许愿功能的次数",
+    "default": 1
+  },
+  "max_daily_rob_attempts": {
+    "type": "int",
+    "description": "每日最多强娶次数",
+    "hint": "每个用户每日允许使用强娶功能的次数（成功与否均扣减）",
+    "default": 2
+  },
+  "max_daily_lock": {
+    "type": "int",
+    "description": "每日最多锁定次数",
+    "hint": "每个用户每日允许使用锁定功能的次数",
+    "default": 1
+  },
+  "show_avatar": {
+    "type": "bool",
+    "description": "是否显示伴侣头像",
+    "hint": "开启后在查询和配对成功消息中显示伴侣头像",
+    "default": true
+  },
+  "avatar_size": {
+    "type": "int",
+    "description": "伴侣头像尺寸规格",
+    "hint": "可选值：1, 2, 3, 4, 5, 40, 100, 140, 640。对应不同头像大小。",
+    "default": 640,
+    "options": [ 1, 2, 3, 4, 5, 40, 100, 140, 640 ]
+  }
 }


### PR DESCRIPTION
更新 napcat 配置支持多主机轮询

- 修改 `_conf_schema.json`，使 `napcat_host` 支持多个地址用逗号分隔。
- 更新 `main.py` 中的 `_init_napcat_config` 方法，支持读取多个 `napcat_host` 并进行格式验证。
- 添加 `_get_current_napcat_host` 方法，用于轮询获取当前使用的 `napcat` 主机。
- 简化 `_get_members` 方法，尝试从所有主机获取群成员信息并处理连接失败。
- 在 `wish_command` 和 `rob_command` 中增加对多个主机的尝试逻辑，确保连接失败时继续尝试其他主机。
- 重构头像下载逻辑，确保在获取头像时能够处理异常情况。
- 保持 `terminate` 方法的原有逻辑，确保插件在被禁用、重载或关闭时正常处理。